### PR TITLE
decorator expression to call/apply expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ava": "^0.15.2",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",
+    "babel-helper-optimise-call-expression": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-runtime": "^6.9.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import babelHelperOptimiseCallExpression from 'babel-helper-optimise-call-expression';
+
 export default function({ types }) {
     return {
         visitor: {
@@ -28,11 +30,24 @@ export default function({ types }) {
                                 path.scope.generateUidIdentifier(name).name;
 
                             path.scope.rename(name, decoratedParamUidName);
+                            const resultantCallExpression =
+                                babelHelperOptimiseCallExpression(
+                                    resultantDecorator.callee.callee,
+                                    types.thisExpression(),
+                                    resultantDecorator.callee.arguments
+                            );
+                            const decoratorExpreesion =
+                                babelHelperOptimiseCallExpression(
+                                    resultantCallExpression,
+                                    types.thisExpression(),
+                                    resultantDecorator.arguments
+                                );
+
                             param.parentPath.get('body').unshiftContainer(
                                 'body', types.variableDeclaration('var', [
                                     types.variableDeclarator(
                                         types.Identifier(decoratedParamUidName),
-                                        resultantDecorator
+                                        decoratorExpreesion
                                     )
                                 ])
                             );


### PR DESCRIPTION
before
````js
// test code: 
function test(name) {
    return function (target) {
        return target;
    };
}

function foo(target) {
   return target;
}

class Bar {
    getName(@test("name") name1) {
        return name1;
    }

     getFoo(@foo name1) {
        return name1;
    }
}

// the transform Bar#getName like
function getName(_name2) {
    var _name3 = test("name")(_name2);
    return _name3;
}

// the transform Bar#getFoo like
function getFoo(_name2) {
    var _name3 = test(_name2);
    return _name3;
}
````

now
````js
// the transform Bar#getName like
function getName(_name2) {
    var _name3 = test.call(this, "name").call(this, _name2);
    return _name3;
}

// the transform Bar#getFoo like
function getFoo(_name2) {
    var _name3 = test.bind(this).call(this, _name2);
    return _name3;
}
````
then we can visit properties of `Bar` in parameter decorators.

thanks  